### PR TITLE
Ignore empty commands

### DIFF
--- a/clictrl.py
+++ b/clictrl.py
@@ -22,6 +22,8 @@ class CommandsController:
     # Otherwise what we get from Bluetooth UART, we just send as
     # a message.
     def exec_user_command(self,fw,cmd,send_reply):
+        if len(cmd) == 0:
+            return
         print("Command from BLE received: ", cmd)
         if cmd[0] == '!':
             argv = cmd.split()


### PR DESCRIPTION
It's not really a problem when we receive an empty command, but with this PR we keep serial logging clean. Without receiving an
empty command will show the traceback:
```
Command from BLE received:  
Traceback (most recent call last):
  File "bt.py", line 129, in irq_handler
  File "main.py", line 404, in ble_receive_callback
  File "clictrl.py", line 26, in exec_user_command
IndexError: string index out of range
```