### PR TITLE
Consistent command reply fix

### DIFF
--- a/clictrl.py
+++ b/clictrl.py
@@ -101,20 +101,20 @@ class CommandsController:
             if argc == 0: return
             method_name = 'cmd_'+argv[0]
             if not hasattr(self.__class__,method_name):
-                send_reply("Unknown command: "+argv[0])
+                send_reply("$Unknown command: "+argv[0])
                 return
 
             # Call the method logically bound to the command name.
             method = getattr(self.__class__, method_name)
             if method(self,argv,argc,send_reply) == False:
-                send_reply("Wrong number of arguments for: "+argv[0])
+                send_reply("$Wrong number of arguments for: "+argv[0])
         elif cmd[0] == '#':
             # Encrypted message.
             idx = cmd.find(' ')
             key_name = cmd[1:idx]
             text = cmd[idx+1:]
             if not self.fw.keychain.has_key(key_name):
-                send_reply("No such key '"+str(key_name)+"'")
+                send_reply("$No such key '"+str(key_name)+"'")
             else:
                 msg = Message(nick=self.fw.config['nick'], text=text, key_name=key_name)
                 self.fw.send_asynchronously(msg,max_delay=0,num_tx=3,relay=True)
@@ -133,7 +133,7 @@ class CommandsController:
         if argc > 2: return False
         elif argc == 2:
             self.fw.config[field] = argv[1] == '1' or argv[1] == 'on'
-        send_reply("%s set to: %s" % (descr,self.fw.config[field]))
+        send_reply("$%s set to: %s" % (descr,self.fw.config[field]))
         return True
 
     def cmd_quiet(self,argv,argc,send_reply):
@@ -152,18 +152,18 @@ class CommandsController:
         if argc > 2: return False
         elif argc == 2:
             self.fw.config['nick'] = argv[1]
-        send_reply("Your nick is: %s" %self.fw.config['nick'])
+        send_reply("$Your nick is: %s" %self.fw.config['nick'])
 
     def cmd_preset(self,argv,argc,send_reply):
         if argc != 2: return False
         if argv[1] in LoRaPresets:
             self.fw.config.update(LoRaPresets[argv[1]])
-            send_reply("Setting bw:"+str(self.fw.config['lora_bw'])+
+            send_reply("$Setting bw:"+str(self.fw.config['lora_bw'])+
                         " cr:"+str(self.fw.config['lora_cr'])+
                         " sp:"+str(self.fw.config['lora_sp']))
             self.fw.lora_reset_and_configure()
         else:
-            send_reply("Valid presets: "+ ", ".join(x for x in LoRaPresets))
+            send_reply("$Valid presets: "+ ", ".join(x for x in LoRaPresets))
         return True
 
     def cmd_pw(self,argv,argc,send_reply):
@@ -174,11 +174,11 @@ class CommandsController:
             except:
                 txpower = 0
             if txpower < 2 or txpower > 20:
-                send_reply("Invalid tx power (dbm). Use 2-20.")
+                send_reply("$Invalid tx power (dbm). Use 2-20.")
             else:
                 self.fw.config['lora_pw'] = txpower
                 self.fw.lora_reset_and_configure()
-        send_reply("TX power set to "+str(self.fw.config['lora_pw']))
+        send_reply("$TX power set to "+str(self.fw.config['lora_pw']))
         return True
 
     def cmd_sp(self,argv,argc,send_reply):
@@ -189,11 +189,11 @@ class CommandsController:
             except:
                 spreading = 0
             if spreading < 6 or spreading > 12:
-                send_reply("Invalid spreading. Use 6-12.")
+                send_reply("$Invalid spreading. Use 6-12.")
             else:
                 self.fw.config['lora_sp'] = spreading
                 self.fw.lora_reset_and_configure()
-        send_reply("Spreading set to "+str(self.fw.config['lora_sp']))
+        send_reply("$Spreading set to "+str(self.fw.config['lora_sp']))
         return True
 
     def cmd_cr(self,argv,argc,send_reply):
@@ -204,11 +204,11 @@ class CommandsController:
             except:
                 cr = 0
             if cr < 5 or cr > 8:
-                send_reply("Invalid coding rate. Use 5-8.")
+                send_reply("$Invalid coding rate. Use 5-8.")
             else:
                 self.fw.config['lora_cr'] = cr 
                 self.fw.lora_reset_and_configure()
-        send_reply("Coding rate set to "+str(self.fw.config['lora_cr']))
+        send_reply("$Coding rate set to "+str(self.fw.config['lora_cr']))
         return True
 
     def cmd_bw(self,argv,argc,send_reply):
@@ -221,12 +221,12 @@ class CommandsController:
             except:
                 bw  = 0
             if not bw in valid_bw_values:
-                send_reply("Invalid bandwidth. Use: "+
+                send_reply("$Invalid bandwidth. Use: "+
                             ", ".join(str(x) for x in valid_bw_values))
             else:
                 self.fw.config['lora_bw'] = bw
                 self.fw.lora_reset_and_configure()
-        send_reply("bandwidth set to "+str(self.fw.config['lora_bw']))
+        send_reply("$bandwidth set to "+str(self.fw.config['lora_bw']))
         return True
 
     def cmd_help(self,argv,argc,send_reply):
@@ -235,7 +235,7 @@ class CommandsController:
         for x in dir(self):
             if x.find("cmd_") != 0: continue
             helpstr += x.replace("cmd_","!")+" "
-        send_reply(helpstr)
+        send_reply("$"+helpstr)
         return True
 
     def cmd_config(self,argv,argc,send_reply):
@@ -243,29 +243,29 @@ class CommandsController:
         if argc == 1:
             settings = ['nick', 'lora_sp','lora_bw','lora_cr','lora_pw','automsg','irc','wifi_default_network','quiet','check_crc']
             for s in settings:
-                send_reply("%s: %s" % (s, repr(self.fw.config.get(s))))
-            send_reply("wifi_enabled: %s" % repr(self.fw.wifi and self.fw.wifi.is_connected()))
+                send_reply("$%s: %s" % (s, repr(self.fw.config.get(s))))
+            send_reply("$wifi_enabled: %s" % repr(self.fw.wifi and self.fw.wifi.is_connected()))
         elif argv[1] == "save":
             self.fw.save_settings()
-            send_reply("Settings saved.")
+            send_reply("$Settings saved.")
         elif argv[1] == "reset":
             self.fw.reset_settings()
-            send_reply("Settings file removed.")
+            send_reply("$Settings file removed.")
         else:
-            send_reply("Valid subcommands: save, reset")
+            send_reply("$Valid subcommands: save, reset")
         return True
 
     def cmd_bat(self,argv,argc,send_reply):
         if argc != 1: return False
         volts = self.fw.get_battery_microvolts()/1000000
         perc = self.fw.get_battery_perc()
-        send_reply("battery %d%%, %.2f volts" % (perc,volts))
+        send_reply("$battery %d%%, %.2f volts" % (perc,volts))
         return True
 
     def cmd_font(self,argv,argc,send_reply):
         if argc != 2: return False
         if argv[1] not in ["big","small"]:
-            send_reply("Use big or small.")
+            send_reply("$Use big or small.")
         else:
             self.fw.scroller.select_font(argv[1])
             self.fw.refresh_view()
@@ -278,64 +278,64 @@ class CommandsController:
             m = self.fw.neighbors[node_id]
             age = time.ticks_diff(time.ticks_ms(),m.ctime) / 1000
             list_item += 1
-            send_reply(str(list_item)+". "+
+            send_reply("$"+str(list_item)+". "+
                         m.sender_to_str()+
                         " ("+m.nick+"> "+m.text+") "+
                         ("%.1f" % age) + " sec ago "+
                         (" with RSSI:%d " % (m.rssi))+
                         "It can see "+str(m.seen)+" nodes.")
         if len(self.fw.neighbors) == 0:
-            send_reply("Nobody around...")
+            send_reply("$Nobody around...")
         return True
 
     def cmd_last(self,argv,argc,send_reply):
         if argc > 2: return False
         count = int(argv[1]) if argc == 2 else 10
         if count < 1:
-            send_reply("Wrong count.")
+            send_reply("$Wrong count.")
         else:
             msglist = self.fw.history.get_records(count-1,count)
             for enc in msglist:
                 m = Message.from_encoded(enc,self.fw.keychain)
                 if m.flags & MessageFlagsMedia:
-                    send_reply(m.nick+"> [%d bytes of media]"%len(m.media_data))
+                    send_reply("$"+m.nick+"> [%d bytes of media]"%len(m.media_data))
                 else:
-                    send_reply(m.nick+"> "+m.text)
+                    send_reply("$"+m.nick+"> "+m.text)
         return True
 
     def cmd_addkey(self,argv,argc,send_reply):
         if argc != 3: return False
         self.fw.keychain.add_key(argv[1],argv[2])
-        send_reply("Key added to keychain.")
+        send_reply("$Key added to keychain.")
         return True
 
     def cmd_delkey(self,argv,argc,send_reply):
         if argc != 2: return False
         if self.fw.keychain.has_key(argv[1]):
             self.fw.keychain.del_key(argv[1])
-            send_reply("Key removed from keychain")
+            send_reply("$Key removed from keychain")
         else:
-            send_reply("No such key: "+argv[1])
+            send_reply("$No such key: "+argv[1])
         return True
 
     def cmd_usekey(self,argv,argc,send_reply):
         if argc != 2: return False
         if self.fw.keychain.has_key(argv[1]):
             self.default_key = argv[1]
-            send_reply("Key set.")
+            send_reply("$Key set.")
         else:
-            send_reply("No such key: "+argv[1])
+            send_reply("$No such key: "+argv[1])
         return True
 
     def cmd_nokey(self,argv,argc,send_reply):
         if argc != 1: return False
         self.default_key = None
-        send_reply("Key unset. New messages will be sent unencrypted.")
+        send_reply("$Key unset. New messages will be sent unencrypted.")
         return True
 
     def cmd_keys(self,argv,argc,send_reply):
         if argc != 1: return False
-        send_reply(", ".join(self.fw.keychain.list_keys()))
+        send_reply("$, ".join(self.fw.keychain.list_keys()))
         return True
 
     def cmd_reset(self,argv,argc,send_reply):
@@ -346,40 +346,40 @@ class CommandsController:
     def cmd_wifi(self,argv,argc,send_reply):
         if argc == 1:
             defnet = self.fw.config.get('wifi_default_network')
-            send_reply("Configured wifi networks:")
+            send_reply("$Configured wifi networks:")
             for ssid in self.fw.config['wifi']:
                 if ssid == defnet: ssid += " (default)"
-                send_reply(ssid)
+                send_reply("$"+ssid)
         elif argc == 4 and argv[1] == 'add':
             self.fw.config['wifi'][argv[2]] = argv[3]
-            send_reply("Network added.")
+            send_reply("$Network added.")
         elif argc == 3 and (argv[1] == 'del' or argv[1] == 'rm'):
             del(self.fw.config['wifi'][argv[2]])
-            send_reply("Network removed.")
+            send_reply("$Network removed.")
         elif argc == 3 and argv[1] == 'start':
             netname = argv[2]
             netpass = self.fw.config['wifi'].get(netname)
             if not netpass:
-                send_reply("No such network: %s" % netname)
+                send_reply("$No such network: %s" % netname)
             else:
                 self.fw.start_wifi(netname,netpass)
-                send_reply("Connecting to %s" % netname)
+                send_reply("$Connecting to %s" % netname)
         elif argc == 2 and argv[1] == 'stop':
             self.fw.stop_wifi()
-            send_reply("WiFi turned off")
+            send_reply("$WiFi turned off")
         else:
-            send_reply("Usage: wifi | wifi add <net> <pass> | wifi del <net> | wifi start <net> | wifi <stop>")
+            send_reply("$Usage: wifi | wifi add <net> <pass> | wifi del <net> | wifi start <net> | wifi <stop>")
         return True
 
     def cmd_irc(self,argv,argc,send_reply):
         if argc == 2 and argv[1] == 'stop':
             self.fw.stop_irc()
-            send_reply("IRC stopped")
+            send_reply("$IRC stopped")
         elif argc == 2 and argv[1] == 'start':
             self.fw.start_irc()
-            send_reply("IRC started")
+            send_reply("$IRC started")
         else:
-            send_reply("Usage: irc start | stop")
+            send_reply("$Usage: irc start | stop")
         return True
 
     def cmd_image(self,argv,argc,send_reply):
@@ -387,7 +387,7 @@ class CommandsController:
         try:
             img = ImageFCI(filename="images/"+argv[1])
             if len(img.encoded) > 200:
-                send_reply("Image must be <= 200 bytes.")
+                send_reply("$Image must be <= 200 bytes.")
             else:
                 msg = Message(flags=MessageFlagsMedia,nick=self.fw.config['nick'],media_type=MessageMediaTypeImageFCI,media_data=img.encoded)
                 self.fw.send_asynchronously(msg,max_delay=0,num_tx=1,relay=True)
@@ -395,12 +395,12 @@ class CommandsController:
                 self.fw.scroller.print(img)
                 self.fw.refresh_view()
         except Exception as e:
-            send_reply("Error loading the image: "+str(e))
+            send_reply("$Error loading the image: "+str(e))
         return True
 
     def cmd_log(self,argv,argc,send_reply):
         self.fw.serial_log_enabled = not self.fw.serial_log_enabled
-        send_reply("Serial logging set to: "+str(self.fw.serial_log_enabled))
+        send_reply("$Serial logging set to: "+str(self.fw.serial_log_enabled))
 
     # This is the same as pressing button 0 on the device.
     def cmd_b0(self,argv,argc,send_reply):

--- a/devices/device_config.heltec_v3.py
+++ b/devices/device_config.heltec_v3.py
@@ -50,6 +50,10 @@ class DeviceConfig:
 
         return battery_uv
 
+    def set_vext_ctrl(status):
+        DeviceConfig.vext_ctrl.on() #invert the value (HIGH = power off, LOW = power on)
+
+
     config['tx_led'] = {
         'pin': 35,
         'inverted': False,      # Set to True if pin on = led off

--- a/devices/device_config.heltec_v3.py
+++ b/devices/device_config.heltec_v3.py
@@ -1,0 +1,60 @@
+### LILYGO T3 v2 1.6 hardware configuration
+
+from machine import Pin, ADC
+
+class DeviceConfig:
+    config = {}
+
+    config['ssd1306']= {
+        'sda': 17,
+        'scl': 18,
+        'xres': 128,
+        'yres': 64,
+    }
+
+    config['vext_ctrl'] = {
+        'pin': 36
+    }
+
+    def power_up(freakwan):
+        # Init battery voltage pin
+        DeviceConfig.adc_ctrl = Pin(37, Pin.OUT) # on heltec v3 we need to switch a mosfet
+        # which gate is on pin 37 to be able to read battery voltage
+        DeviceConfig.adc_ctrl.on() # make sure pin is in high state when we are not reading
+        DeviceConfig.battery_adc = ADC(Pin(1))
+
+        DeviceConfig.battery_adc.atten(ADC.ATTN_2_5DB)
+
+        # Bind the button present on the board. It is connected to
+        # Pin 0, and goes low when pressed.
+        button0 = Pin(0,Pin.IN)
+        button0.irq(freakwan.button_0_pressed,Pin.IRQ_FALLING)
+
+        DeviceConfig.vext_ctrl = Pin(36, Pin.OUT) # on heltec v3 there's another mosfet to enable power to OLED
+        # and possibile external devices, we need to pull this pin low to let current flow
+        DeviceConfig.vext_ctrl.off()
+
+    def get_battery_microvolts():
+        adc_ctrl.off() # switch mosfet low to read battery voltage
+        battery_uv = DeviceConfig.battery_adc.read_uv()*4.9 # 390k - 100k voltage divider,
+        # this value SHOULD be manually calibrated for your board to accomodate tolerances
+        # we should also think on an efficient way to average out values and eliminate outliers
+        adc_ctrl.on()
+
+        return battery_uv
+
+    config['tx_led'] = {
+        'pin': 35,
+        'inverted': False,      # Set to True if pin on = led off
+    }
+
+    # Pin configuration for the SX1262.
+    config['sx1262'] = {
+        'busy': 13,
+        'miso': 11,
+        'mosi': 10,
+        'clock': 9,
+        'chipselect': 8,
+        'reset': 12,
+        'dio': 14,
+    }

--- a/devices/device_config.heltec_v3.py
+++ b/devices/device_config.heltec_v3.py
@@ -1,4 +1,4 @@
-### LILYGO T3 v2 1.6 hardware configuration
+### Heltec V3 hardware configuration
 
 from machine import Pin, ADC
 import time

--- a/devices/device_config.heltec_v3.py
+++ b/devices/device_config.heltec_v3.py
@@ -50,10 +50,6 @@ class DeviceConfig:
 
         return battery_uv
 
-    def set_vext_ctrl(status):
-        DeviceConfig.vext_ctrl.on() #invert the value (HIGH = power off, LOW = power on)
-
-
     config['tx_led'] = {
         'pin': 35,
         'inverted': False,      # Set to True if pin on = led off

--- a/devices/device_config.heltec_v3.py
+++ b/devices/device_config.heltec_v3.py
@@ -1,6 +1,7 @@
 ### LILYGO T3 v2 1.6 hardware configuration
 
 from machine import Pin, ADC
+import time
 
 class DeviceConfig:
     config = {}
@@ -8,6 +9,7 @@ class DeviceConfig:
     config['ssd1306']= {
         'sda': 17,
         'scl': 18,
+        'rst': 21,
         'xres': 128,
         'yres': 64,
     }
@@ -29,17 +31,22 @@ class DeviceConfig:
         # Pin 0, and goes low when pressed.
         button0 = Pin(0,Pin.IN)
         button0.irq(freakwan.button_0_pressed,Pin.IRQ_FALLING)
-
-        DeviceConfig.vext_ctrl = Pin(36, Pin.OUT) # on heltec v3 there's another mosfet to enable power to OLED
+        DeviceConfig.vext_ctrl = Pin(DeviceConfig.config['vext_ctrl']['pin'], Pin.OUT) # on heltec v3 there's another mosfet to enable power to OLED
         # and possibile external devices, we need to pull this pin low to let current flow
         DeviceConfig.vext_ctrl.off()
+        oled_rst = Pin(DeviceConfig.config['ssd1306']['rst'], Pin.OUT)
+        oled_rst.off()
+        time.sleep_ms(50)
+        oled_rst.on()
+        time.sleep_ms(50)
+
 
     def get_battery_microvolts():
-        adc_ctrl.off() # switch mosfet low to read battery voltage
+        DeviceConfig.adc_ctrl.off() # switch mosfet low to read battery voltage
         battery_uv = DeviceConfig.battery_adc.read_uv()*4.9 # 390k - 100k voltage divider,
         # this value SHOULD be manually calibrated for your board to accomodate tolerances
         # we should also think on an efficient way to average out values and eliminate outliers
-        adc_ctrl.on()
+        DeviceConfig.adc_ctrl.on()
 
         return battery_uv
 

--- a/freakwan.py
+++ b/freakwan.py
@@ -864,6 +864,8 @@ class FreakWAN:
                     self.scroller.print("")
                     self.scroller.print("Device frozen. Switching off in 15 seconds.")
                     self.refresh_view()
+                    if 'vext_ctrl' in self.config:
+                        self.config.vext_ctrl.on() #cut power to the OLED on Heltec V3 by pulling the vext mosfet gate up
                     time.sleep_ms(15000)
                     self.power_off(5000)
 

--- a/freakwan.py
+++ b/freakwan.py
@@ -713,7 +713,7 @@ class FreakWAN:
         if self.display and hasattr(self.display,'poweroff'):
             self.display.poweroff()
         if 'vext_ctrl' in self.config:
-            self.config.vext_ctrl.on() #cut power to the OLED on Heltec V3 by pulling the gate up
+            self.config.vext_ctrl.on() #cut power to the OLED on Heltec V3 by pulling the vext mosfet gate up
         machine.deepsleep(offtime)
 
     # We want to reply to CLI inputs even if written directly in the

--- a/freakwan.py
+++ b/freakwan.py
@@ -712,8 +712,6 @@ class FreakWAN:
         self.lora.reset()
         if self.display and hasattr(self.display,'poweroff'):
             self.display.poweroff()
-        if 'vext_ctrl' in self.config:
-            self.config.vext_ctrl.on() #cut power to the OLED on Heltec V3 by pulling the vext mosfet gate up
         machine.deepsleep(offtime)
 
     # We want to reply to CLI inputs even if written directly in the
@@ -864,8 +862,6 @@ class FreakWAN:
                     self.scroller.print("")
                     self.scroller.print("Device frozen. Switching off in 15 seconds.")
                     self.refresh_view()
-                    if 'vext_ctrl' in self.config:
-                        self.config.vext_ctrl.on() #cut power to the OLED on Heltec V3 by pulling the vext mosfet gate up
                     time.sleep_ms(15000)
                     self.power_off(5000)
 

--- a/freakwan.py
+++ b/freakwan.py
@@ -712,6 +712,8 @@ class FreakWAN:
         self.lora.reset()
         if self.display and hasattr(self.display,'poweroff'):
             self.display.poweroff()
+        if 'vext_ctrl' in self.config:
+            self.config.vext_ctrl.on() #cut power to the OLED on Heltec V3 by pulling the gate up
         machine.deepsleep(offtime)
 
     # We want to reply to CLI inputs even if written directly in the


### PR DESCRIPTION
resolves #22 

I added `$` character to each command reply.
It might be unnecessary in some conditions like replies to commands with wrong number of arguments.
In general I think it's good anyway to easily distiguish between messages